### PR TITLE
feat: update platform support and improve shutdown handling for NextUI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,9 @@ TARGET = minui-power-control
 TAG ?= $(shell git describe --tags --abbrev=0 2>/dev/null || echo "")
 
 ARCHITECTURES := arm arm64
-PLATFORMS := tg5040 miyoomini rg35xxplus
+PLATFORMS := tg5040 tg5050 my355 miyoomini rg35xxplus
 
-MINUI_PRESENTER_VERSION := 0.9.0
+MINUI_PRESENTER_VERSION := 0.12.0
 MAKESELF_VERSION := 2.5.0
 
 clean:

--- a/README.md
+++ b/README.md
@@ -13,10 +13,12 @@ The app is especially aimed at developers creating emulator paks, making it easy
 This app is designed and tested on the following MinUI platforms and devices:
 
 - `tg5040`: Trimui Brick (formerly `tg3040`), Trimui Smart Pro
+- `tg5050`: Trimui Smart Pro S (NextUI only)
+- `my355`: Miyoo Flip
 - `miyoomini`: Miyoo Mini Plus (_not_ the Miyoo Mini)
 - `rg35xxplus`: RG-35XX Plus, RG-34XX, RG-35XX H, RG-35XX SP
 
-Deep sleep is currently only supported on the Trimui Brick and Trimui Smart Pro.
+Deep sleep is supported on Trimui Brick, Trimui Smart Pro, Trimui Smart Pro S, and Miyoo Flip.
 
 ## Features
 

--- a/bin/launch
+++ b/bin/launch
@@ -41,11 +41,22 @@ main() {
         fi
     fi
 
-    allowed_platforms="tg5040 rg35xxplus miyoomini"
+    if [ "$PLATFORM" = "tg5050" ] && [ -z "$DEVICE" ]; then
+        export DEVICE="smartpros"
+    fi
+
+    if [ "$PLATFORM" = "my355" ] && [ -z "$DEVICE" ]; then
+        export DEVICE="my355"
+    fi
+
+    allowed_platforms="tg5040 tg5050 my355 rg35xxplus miyoomini"
     if ! echo "$allowed_platforms" | grep -q "$PLATFORM"; then
         echo "$PLATFORM is not a supported platform."
         exit 1
     fi
+
+    # Pak launchers normally export SYSTEM_PATH; default it for standalone runs.
+    export SYSTEM_PATH="${SYSTEM_PATH:-/mnt/SDCARD/.system/$PLATFORM}"
 
     if ! command -v minui-presenter >/dev/null 2>&1; then
         echo "minui-presenter binary not found."

--- a/bin/shutdown
+++ b/bin/shutdown
@@ -29,7 +29,30 @@ shutdown_system() {
     echo "Shutting down system..."
     show_message "Powering off" forever
     sync
-    poweroff
+    if [ "$IS_NEXT" = "yes" ]; then
+        # NextUI's MinUI.pak/launch.sh polls /tmp/poweroff and calls poweroff_next
+        # itself once the foreground process exits.
+        touch /tmp/poweroff
+        killall -TERM nextui.elf 2>/dev/null || true
+        if [ -f /tmp/next ]; then
+            ACTIVE_PAK=$(cat /tmp/next | tr -d "'\"")
+            if [ -n "$ACTIVE_PAK" ]; then
+                PAK_DIR=$(dirname "$ACTIVE_PAK")
+                # BusyBox has no pkill; walk /proc and match cmdline ourselves.
+                for proc in /proc/[0-9]*/cmdline; do
+                    cmdline=$(tr '\0' ' ' < "$proc" 2>/dev/null)
+                    case "$cmdline" in
+                        *"$PAK_DIR"*)
+                            pid=${proc#/proc/}; pid=${pid%/cmdline}
+                            kill -TERM "$pid" 2>/dev/null || true
+                            ;;
+                    esac
+                done
+            fi
+        fi
+    else
+        poweroff
+    fi
     while :; do
         sleep 1
     done
@@ -37,7 +60,7 @@ shutdown_system() {
 
 main() {
     if [ -f /tmp/powercontrol-emulator-pid ]; then
-        PROCESS_PID=$(cat /tmp/emulator_pid)
+        PROCESS_PID=$(cat /tmp/powercontrol-emulator-pid)
         echo "Emulator PID file found. Killing the emulator process with PID: $PROCESS_PID"
 
         if [ -z "$PROCESS_PID" ] || ! kill -0 "$PROCESS_PID" 2>/dev/null; then

--- a/bin/suspend
+++ b/bin/suspend
@@ -58,7 +58,7 @@ fallback_suspend() {
 
 main() {
     if [ -f /tmp/powercontrol-emulator-pid ]; then
-        PROCESS_PID=$(cat /tmp/emulator_pid)
+        PROCESS_PID=$(cat /tmp/powercontrol-emulator-pid)
         echo "Emulator PID file found. Killing the emulator process with PID: $PROCESS_PID"
 
         if [ -z "$PROCESS_PID" ] || ! kill -0 "$PROCESS_PID" 2>/dev/null; then

--- a/src/button-handler.go
+++ b/src/button-handler.go
@@ -11,10 +11,10 @@ import (
 )
 
 const (
-	powerKeyCode  = 116 // Power button key code
-	devicePath    = "/dev/input/event1"
-	shortPressMax = 2 * time.Second
-	coolDownTime  = 1 * time.Second
+	powerKeyCode    = 116 // KEY_POWER
+	powerKeyCodeAlt = 102 // some MY355 stacks expose power as 102
+	shortPressMax   = 2 * time.Second
+	coolDownTime    = 1 * time.Second
 )
 
 var (
@@ -24,14 +24,28 @@ var (
 	shutdownScript = filepath.Join(rootPath, "shutdown")
 )
 
+func openPowerDevice() (*evdev.InputDevice, error) {
+	switch os.Getenv("PLATFORM") {
+	case "tg5050", "my355":
+		return evdev.Open("/dev/input/event2")
+	default:
+		return evdev.Open("/dev/input/event1")
+	}
+}
+
+func isPowerKey(code evdev.EvCode) bool {
+	return code == powerKeyCode || code == powerKeyCodeAlt
+}
+
 func main() {
-	dev, err := evdev.Open(devicePath)
+	dev, err := openPowerDevice()
 	if err != nil {
 		log.Fatalf("Failed to open input device: %v", err)
 	}
-	log.Printf("Listening on device: %s\n", devicePath)
+	log.Printf("Listening on device: %s\n", dev.Path())
 
 	var pressTime time.Time
+	var holdTimer *time.Timer
 	var cooldownUntil time.Time
 
 	for {
@@ -45,28 +59,38 @@ func main() {
 			continue
 		}
 
-		if event.Type == evdev.EV_KEY && event.Code == powerKeyCode {
-			if event.Value == 0 && !pressTime.IsZero() {
-				// Key released
-				duration := time.Since(pressTime)
-				pressTime = time.Time{} // Reset
+		if event.Type != evdev.EV_KEY || !isPowerKey(event.Code) {
+			continue
+		}
 
-				if duration < shortPressMax {
-					log.Println("Short press detected, suspending...")
-					runScript(suspendScript)
-					cooldownUntil = time.Now().Add(coolDownTime)
-				}
-			} else if event.Value == 1 {
-				// Key pressed
-				pressTime = time.Now()
-			} else if event.Value == 2 {
-				// Key held down
-				duration := time.Since(pressTime)
-				if duration >= shortPressMax {
-					log.Println("Button held down for 2 seconds, shutting down...")
-					runScript(shutdownScript)
-					cooldownUntil = time.Now().Add(coolDownTime)
-				}
+		switch event.Value {
+		case 1:
+			// Key pressed — arm a timer for the long-hold action.
+			// Some power-key drivers (e.g. my355's rk805 pwrkey) never emit
+			// the autorepeat (value=2) events, so hold detection can't rely on them.
+			pressTime = time.Now()
+			if holdTimer != nil {
+				holdTimer.Stop()
+			}
+			holdTimer = time.AfterFunc(shortPressMax, func() {
+				log.Println("Button held for 2 seconds, shutting down...")
+				runScript(shutdownScript)
+			})
+		case 0:
+			// Key released. If timer hadn't fired yet, this is a short press.
+			if pressTime.IsZero() {
+				continue
+			}
+			pressTime = time.Time{}
+			stopped := false
+			if holdTimer != nil {
+				stopped = holdTimer.Stop()
+				holdTimer = nil
+			}
+			if stopped {
+				log.Println("Short press detected, suspending...")
+				runScript(suspendScript)
+				cooldownUntil = time.Now().Add(coolDownTime)
 			}
 		}
 	}


### PR DESCRIPTION
- Added my355 & tg5050
- Fixed what I believe to a typo surrounding  emulator_pid & powercontrol-emulator-pid
- On NextUI, touch /tmp/poweroff instead of directly powering the device off, potentially triggering limbo
- Updated the presenter to latest (this version also supports the platforms I added)